### PR TITLE
Add Country-Specific Filtering for Barclays Using Factory Overload (Task 1.3)

### DIFF
--- a/Enums/Country.cs
+++ b/Enums/Country.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TradeFilteringApp.Enums
+{
+    public enum Country
+    {
+        USA,
+        England,
+        Ukraine,
+        India
+    }
+}

--- a/Filters/BarclaysEnglandFilter.cs
+++ b/Filters/BarclaysEnglandFilter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TradeFilteringApp.Models;
+
+namespace TradeFilteringApp.Filters
+{
+    public class BarclaysEnglandFilter : IFilter
+    {
+        public IEnumerable<Trade> Match(IEnumerable<Trade> trades)
+        {
+            return trades.Where(t =>
+                t.Type == "Future" &&
+                t.Amount > 100);
+        }
+    }
+}

--- a/Filters/BarclaysUSAFilter.cs
+++ b/Filters/BarclaysUSAFilter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TradeFilteringApp.Models;
+
+namespace TradeFilteringApp.Filters
+{
+    public class BarclaysUSAFilter : IFilter
+    {
+        public IEnumerable<Trade> Match(IEnumerable<Trade> trades)
+        {
+            return trades.Where(t =>
+                t.Type == "Option" &&
+                t.SubType == "NyOption" &&
+                t.Amount > 50);
+        }
+    }
+}

--- a/Filters/FilterFactory.cs
+++ b/Filters/FilterFactory.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using TradeFilteringApp.Enums;
 
 namespace TradeFilteringApp.Filters
@@ -19,6 +15,21 @@ namespace TradeFilteringApp.Filters
                 Bank.Deutsche => new DeutscheFilter(),
                 _ => throw new NotImplementedException("Unsupported bank")
             };
+        }
+
+        public static IFilter CreateFilter(Bank bank, Country country)
+        {
+            if (bank == Bank.Barclays)
+            {
+                return country switch
+                {
+                    Country.USA => new BarclaysUSAFilter(),
+                    Country.England => new BarclaysEnglandFilter(),
+                    _ => new BarclaysFilter()
+                };
+            }
+
+            return CreateFilter(bank);
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -17,15 +17,17 @@ class Program
             new() { Type = "Option", SubType = "NewOption", Amount = 100 },
             new() { Type = "Option", SubType = "NewOption", Amount = 130 },
             new() { Type = "Future", Amount = 80 },
-            new() { Type = "Option", Amount = 200 },
+            new() { Type = "Future", Amount = 150 },
         };
 
         var tradeFilter = new TradeFilter();
 
         TestFilter(trades, tradeFilter, Bank.Bofa);
         TestFilter(trades, tradeFilter, Bank.Connacord);
-        TestFilter(trades, tradeFilter, Bank.Barclays);
         TestFilter(trades, tradeFilter, Bank.Deutsche);
+        TestFilter(trades, tradeFilter, Bank.Barclays);
+        TestFilterByCountry(trades, tradeFilter, Bank.Barclays, Country.USA);
+        TestFilterByCountry(trades, tradeFilter, Bank.Barclays, Country.England);
     }
 
     static void TestFilter(List<Trade> trades, TradeFilter tradeFilter, Bank bank)
@@ -35,6 +37,26 @@ class Program
         try
         {
             var filtered = tradeFilter.FilterForBank(trades, bank);
+
+            foreach (var trade in filtered)
+            {
+                Console.WriteLine($"Type: {trade.Type}, SubType: {trade.SubType}, Amount: {trade.Amount}");
+            }
+        }
+        catch (NotImplementedException ex)
+        {
+            Console.WriteLine(ex.Message);
+        }
+    }
+
+    static void TestFilterByCountry(List<Trade> trades, TradeFilter tradeFilter, Bank bank, Country country)
+    {
+        Console.WriteLine($"\n--- Filtered Trades for {bank} in {country} ---");
+
+        try
+        {
+            var filtered = tradeFilter.FilterForBank(trades, bank, country);
+
             foreach (var trade in filtered)
             {
                 Console.WriteLine($"Type: {trade.Type}, SubType: {trade.SubType}, Amount: {trade.Amount}");

--- a/Services/TradeFilter.cs
+++ b/Services/TradeFilter.cs
@@ -17,5 +17,12 @@ namespace TradeFilteringApp.Services
 
             return filter.Match(trades);
         }
+
+        public IEnumerable<Trade> FilterForBank(IEnumerable<Trade> trades, Bank bank, Country country)
+        {
+            var filter = FilterFactory.CreateFilter(bank, country);
+
+            return filter.Match(trades);
+        }
     }
 }


### PR DESCRIPTION
This PR adds support for country-specific trade filtering for Barclays without modifying the TradeFilter logic, keeping the class Open/Closed Principle compliant.

Changes:

Introduced Country enum

Implemented BarclaysUSAFilter and BarclaysEnglandFilter classes

Extended FilterFactory with an overloaded CreateFilter(Bank, Country) method

Overloaded TradeFilter.FilterForBank to accept a Country parameter

Updated Program.cs to verify both USA and England Barclays filtering logic

Barclays Filtering Rules:

USA: Type == Option && SubType == NyOption && Amount > 50

England: Type == Future && Amount > 100